### PR TITLE
SpoofaxWithCore/134

### DIFF
--- a/org.metaborg.spoofax.eclipse.externaldeps/pom.xml
+++ b/org.metaborg.spoofax.eclipse.externaldeps/pom.xml
@@ -63,6 +63,7 @@
     <dependency>
       <groupId>com.google.code.findbugs</groupId>
       <artifactId>jsr305</artifactId>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>aopalliance</groupId>


### PR DESCRIPTION
got rid of jsr305, junit, hamcrest-core dependencies
