### PR TITLE
Add SPT TestRunner for Eclipse to the Spoofax features.

### DIFF
--- a/org.metaborg.spoofax.eclipse.feature/feature.xml
+++ b/org.metaborg.spoofax.eclipse.feature/feature.xml
@@ -104,13 +104,6 @@
     unpack="false"
   />
   
-  <!-- SPT test runner -->
-  <plugin
-    id="org.metaborg.spt.testrunner.eclipse"
-    version="2.1.0.qualifier"
-    unpack="false"
-  />
-
   <!-- Languages used at runtime by other languages -->
   <plugin
     id="org.metaborg.meta.lang.analysis.eclipse"

--- a/org.metaborg.spoofax.eclipse.feature/feature.xml
+++ b/org.metaborg.spoofax.eclipse.feature/feature.xml
@@ -103,6 +103,13 @@
     version="2.1.0.qualifier"
     unpack="false"
   />
+  
+  <!-- SPT test runner -->
+  <plugin
+    id="org.metaborg.spt.testrunner.eclipse"
+    version="2.1.0.qualifier"
+    unpack="false"
+  />
 
   <!-- Languages used at runtime by other languages -->
   <plugin

--- a/org.metaborg.spoofax.eclipse.meta.feature/feature.xml
+++ b/org.metaborg.spoofax.eclipse.meta.feature/feature.xml
@@ -145,6 +145,11 @@
     version="2.1.0.qualifier"
     unpack="true"
   />
+  <plugin
+    id="org.metaborg.spt.testrunner.eclipse"
+    version="2.1.0.qualifier"
+    unpack="false"
+  />
   
   <!-- Other dependencies, unpack some plugins for access to its JAR/native files. -->
   <plugin

--- a/org.metaborg.spoofax.eclipse/launch/Spoofax Eclipse plugin.launch
+++ b/org.metaborg.spoofax.eclipse/launch/Spoofax Eclipse plugin.launch
@@ -20,7 +20,7 @@
 <listEntry value="org.eclipse.debug.ui.launchGroup.run"/>
 </listAttribute>
 <booleanAttribute key="org.eclipse.jdt.launching.ATTR_USE_START_ON_FIRST_THREAD" value="true"/>
-<stringAttribute key="org.eclipse.jdt.launching.JRE_CONTAINER" value="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7"/>
+<stringAttribute key="org.eclipse.jdt.launching.JRE_CONTAINER" value="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 <stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value="-os ${target.os} -ws ${target.ws} -arch ${target.arch} -nl ${target.nl} -debug -clean"/>
 <stringAttribute key="org.eclipse.jdt.launching.SOURCE_PATH_PROVIDER" value="org.eclipse.pde.ui.workbenchClasspathProvider"/>
 <stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-server -Xmx2G -Xmx2G -XX:MaxPermSize=256M -Xss16m"/>

--- a/org.metaborg.spoofax.eclipse/src/main/java/org/metaborg/spoofax/eclipse/editor/EditorUpdateJob.java
+++ b/org.metaborg.spoofax.eclipse/src/main/java/org/metaborg/spoofax/eclipse/editor/EditorUpdateJob.java
@@ -118,7 +118,7 @@ public class EditorUpdateJob<I extends IInputUnit, P extends IParseUnit, A exten
 
 
     @Override public boolean belongsTo(Object family) {
-        return input.equals(family);
+        return input.equals(family) || editor.equals(family);
     }
 
     @Override protected IStatus run(final IProgressMonitor monitor) {

--- a/org.metaborg.spoofax.eclipse/src/main/java/org/metaborg/spoofax/eclipse/editor/IEclipseEditor.java
+++ b/org.metaborg.spoofax.eclipse/src/main/java/org/metaborg/spoofax/eclipse/editor/IEclipseEditor.java
@@ -40,6 +40,12 @@ public interface IEclipseEditor<F> extends IEditor, ITextEditor {
      *         disposed.
      */
     @Nullable SourceViewerConfiguration configuration();
+    
+    
+    /**
+     * @return True if the editor is updating. False otherwise.
+     */
+    boolean editorIsUpdating();
 
 
     /**

--- a/org.metaborg.spoofax.eclipse/src/main/java/org/metaborg/spoofax/eclipse/editor/MetaBorgEditor.java
+++ b/org.metaborg.spoofax.eclipse/src/main/java/org/metaborg/spoofax/eclipse/editor/MetaBorgEditor.java
@@ -239,6 +239,12 @@ public abstract class MetaBorgEditor<I extends IInputUnit, P extends IParseUnit,
     }
 
 
+    @Override public boolean editorIsUpdating() {
+        final Job[] existingJobs = jobManager.find(this);
+        return existingJobs.length > 0;
+    }
+
+
     @Override public ISelectionProvider selectionProvider() {
         return getSelectionProvider();
     }

--- a/org.metaborg.spoofax.eclipse/src/main/java/org/metaborg/spoofax/eclipse/editor/MetaBorgSourceViewerConfiguration.java
+++ b/org.metaborg.spoofax.eclipse/src/main/java/org/metaborg/spoofax/eclipse/editor/MetaBorgSourceViewerConfiguration.java
@@ -55,21 +55,20 @@ public class MetaBorgSourceViewerConfiguration<I extends IInputUnit, P extends I
 
 
     public MetaBorgSourceViewerConfiguration(IEclipseResourceService resourceService, IInputUnitService<I> unitService,
-        ISyntaxService<I, P> syntaxService,  IParseResultRequester<I, P> parseResultRequester,
+        ISyntaxService<I, P> syntaxService, IParseResultRequester<I, P> parseResultRequester,
         IAnalysisResultRequester<I, A> analysisResultRequester, IResolverService<P, A> referenceResolver,
-        IHoverService<P, A> hoverService, IPreferenceStore preferenceStore,
-        IEclipseEditor<F> editor) {
+        IHoverService<P, A> hoverService, IPreferenceStore preferenceStore, IEclipseEditor<F> editor) {
         super(preferenceStore);
 
         this.resourceService = resourceService;
         this.unitService = unitService;
         this.syntaxService = syntaxService;
-       
+
         this.parseResultRequester = parseResultRequester;
         this.analysisResultRequester = analysisResultRequester;
         this.referenceResolver = referenceResolver;
         this.hoverService = hoverService;
-        
+
 
         this.editor = editor;
     }
@@ -96,7 +95,7 @@ public class MetaBorgSourceViewerConfiguration<I extends IInputUnit, P extends I
 
         final ContentAssistant assistant = new ContentAssistant();
         final IInformationControlCreator informationControlCreator = getCompletionInformationControlCreator();
-        final SpoofaxContentAssistProcessor<I, P> processor = new SpoofaxContentAssistProcessor<>(unitService, 
+        final SpoofaxContentAssistProcessor<I, P> processor = new SpoofaxContentAssistProcessor<>(unitService,
             parseResultRequester, informationControlCreator, resource, document, language);
         assistant.setContentAssistProcessor(processor, IDocument.DEFAULT_CONTENT_TYPE);
         assistant.setRepeatedInvocationMode(true);
@@ -123,7 +122,7 @@ public class MetaBorgSourceViewerConfiguration<I extends IInputUnit, P extends I
             return new IHyperlinkDetector[] { new URLHyperlinkDetector() };
         }
 
-        return new IHyperlinkDetector[] { new SpoofaxHyperlinkDetector<I, P, A>(resourceService, parseResultRequester,
+        return new IHyperlinkDetector[] { new SpoofaxHyperlinkDetector<>(resourceService, parseResultRequester,
             analysisResultRequester, referenceResolver, resource, language, editor), new URLHyperlinkDetector() };
     }
 
@@ -138,7 +137,7 @@ public class MetaBorgSourceViewerConfiguration<I extends IInputUnit, P extends I
         }
 
         return new SpoofaxTextHover<>(parseResultRequester, analysisResultRequester, hoverService, resource, language,
-            (ISourceViewerExtension2) editor.sourceViewer());
+            editor, (ISourceViewerExtension2) editor.sourceViewer());
     }
 
     public IInformationControlCreator getInformationControlCreator(ISourceViewer sourceViewer) {

--- a/org.metaborg.spoofax.eclipse/src/main/java/org/metaborg/spoofax/eclipse/editor/tracing/SpoofaxHyperlinkDetector.java
+++ b/org.metaborg.spoofax.eclipse/src/main/java/org/metaborg/spoofax/eclipse/editor/tracing/SpoofaxHyperlinkDetector.java
@@ -50,7 +50,6 @@ public class SpoofaxHyperlinkDetector<I extends IInputUnit, P extends IParseUnit
 
     @Override public @Nullable IHyperlink[] detectHyperlinks(ITextViewer textViewer, IRegion region, boolean multiple) {
         if(!resolverService.available(language) || editor.editorIsUpdating()) {
-            logger.info("Skipping reference resolution");
             return null;
         }
 

--- a/org.metaborg.spoofax.eclipse/src/main/java/org/metaborg/spoofax/eclipse/editor/tracing/SpoofaxHyperlinkDetector.java
+++ b/org.metaborg.spoofax.eclipse/src/main/java/org/metaborg/spoofax/eclipse/editor/tracing/SpoofaxHyperlinkDetector.java
@@ -5,7 +5,6 @@ import org.eclipse.jface.text.IRegion;
 import org.eclipse.jface.text.ITextViewer;
 import org.eclipse.jface.text.hyperlink.AbstractHyperlinkDetector;
 import org.eclipse.jface.text.hyperlink.IHyperlink;
-import org.eclipse.ui.texteditor.ITextEditor;
 import org.metaborg.core.MetaborgException;
 import org.metaborg.core.analysis.IAnalyzeUnit;
 import org.metaborg.core.language.ILanguageImpl;
@@ -15,12 +14,13 @@ import org.metaborg.core.syntax.IInputUnit;
 import org.metaborg.core.syntax.IParseUnit;
 import org.metaborg.core.tracing.IResolverService;
 import org.metaborg.core.tracing.Resolution;
+import org.metaborg.spoofax.eclipse.editor.IEclipseEditor;
 import org.metaborg.spoofax.eclipse.resource.IEclipseResourceService;
 import org.metaborg.spoofax.eclipse.util.Nullable;
 import org.metaborg.util.log.ILogger;
 import org.metaborg.util.log.LoggerUtils;
 
-public class SpoofaxHyperlinkDetector<I extends IInputUnit, P extends IParseUnit, A extends IAnalyzeUnit>
+public class SpoofaxHyperlinkDetector<I extends IInputUnit, P extends IParseUnit, A extends IAnalyzeUnit, F>
     extends AbstractHyperlinkDetector {
     private static final ILogger logger = LoggerUtils.logger(SpoofaxHyperlinkDetector.class);
 
@@ -31,12 +31,12 @@ public class SpoofaxHyperlinkDetector<I extends IInputUnit, P extends IParseUnit
 
     private final FileObject resource;
     private final ILanguageImpl language;
-    private final ITextEditor editor;
+    private final IEclipseEditor<F> editor;
 
 
     public SpoofaxHyperlinkDetector(IEclipseResourceService resourceService,
         IParseResultRequester<I, P> parseResultRequester, IAnalysisResultRequester<I, A> analysisResultRequester,
-        IResolverService<P, A> resolverService, FileObject resource, ILanguageImpl language, ITextEditor editor) {
+        IResolverService<P, A> resolverService, FileObject resource, ILanguageImpl language, IEclipseEditor<F> editor) {
         this.resourceService = resourceService;
         this.parseResultRequester = parseResultRequester;
         this.analysisResultRequester = analysisResultRequester;
@@ -49,7 +49,8 @@ public class SpoofaxHyperlinkDetector<I extends IInputUnit, P extends IParseUnit
 
 
     @Override public @Nullable IHyperlink[] detectHyperlinks(ITextViewer textViewer, IRegion region, boolean multiple) {
-        if(!resolverService.available(language)) {
+        if(!resolverService.available(language) || editor.editorIsUpdating()) {
+            logger.info("Skipping reference resolution");
             return null;
         }
 

--- a/org.metaborg.spoofax.eclipse/src/main/java/org/metaborg/spoofax/eclipse/editor/tracing/SpoofaxTextHover.java
+++ b/org.metaborg.spoofax.eclipse/src/main/java/org/metaborg/spoofax/eclipse/editor/tracing/SpoofaxTextHover.java
@@ -17,12 +17,13 @@ import org.metaborg.core.syntax.IInputUnit;
 import org.metaborg.core.syntax.IParseUnit;
 import org.metaborg.core.tracing.Hover;
 import org.metaborg.core.tracing.IHoverService;
+import org.metaborg.spoofax.eclipse.editor.IEclipseEditor;
 import org.metaborg.spoofax.eclipse.util.Nullable;
 import org.metaborg.util.iterators.Iterables2;
 import org.metaborg.util.log.ILogger;
 import org.metaborg.util.log.LoggerUtils;
 
-public class SpoofaxTextHover<I extends IInputUnit, P extends IParseUnit, A extends IAnalyzeUnit>
+public class SpoofaxTextHover<I extends IInputUnit, P extends IParseUnit, A extends IAnalyzeUnit, F>
     implements ITextHover {
     private static final ILogger logger = LoggerUtils.logger(SpoofaxTextHover.class);
 
@@ -32,25 +33,27 @@ public class SpoofaxTextHover<I extends IInputUnit, P extends IParseUnit, A exte
 
     private final FileObject resource;
     private final ILanguageImpl language;
+    private final IEclipseEditor<F> editor;
     private final ISourceViewerExtension2 sourceViewer;
 
 
     public SpoofaxTextHover(IParseResultRequester<I, P> parseResultRequester,
         IAnalysisResultRequester<I, A> analysisResultRequester, IHoverService<P, A> hoverService, FileObject resource,
-        ILanguageImpl language, ISourceViewerExtension2 sourceViewer) {
+        ILanguageImpl language, IEclipseEditor<F> editor, ISourceViewerExtension2 sourceViewer) {
         this.parseResultRequester = parseResultRequester;
         this.analysisResultRequester = analysisResultRequester;
         this.hoverService = hoverService;
 
         this.resource = resource;
         this.language = language;
+        this.editor = editor;
         this.sourceViewer = sourceViewer;
     }
 
 
     @Override public String getHoverInfo(ITextViewer viewer, IRegion region) {
         final StringBuilder stringBuilder = annotationHover(region);
-        if(hoverService.available(language)) {
+        if(hoverService.available(language) && !editor.editorIsUpdating()) {
             final int offset = region.getOffset();
 
             Hover hover = null;


### PR DESCRIPTION
The SPT testrunner for Eclipse is now in a useable state.
It still needs many extra features but for now it is at least useable.

Invoke it via `Right Click on a project -> Spoofax -> Run All SPT Tests`.
