### PR TITLE
Moved toggle commands from runtime to meta tooling

### DIFF
--- a/org.metaborg.spoofax.eclipse.meta/plugin.xml
+++ b/org.metaborg.spoofax.eclipse.meta/plugin.xml
@@ -138,14 +138,67 @@
       class="org.metaborg.spoofax.eclipse.meta.issue.ReportIssueHandler"
     />
   </extension>
+
+  <!-- Disabling long-running operation commands -->
+  <extension point="org.eclipse.ui.commands">
+    <command id="org.metaborg.spoofax.eclipse.command.disable.build" name="Disable builds">
+      <state class="org.eclipse.ui.handlers.RegistryToggleState" id="org.eclipse.ui.commands.toggleState" />
+    </command>
+    <command id="org.metaborg.spoofax.eclipse.command.disable.incrementalbuild" name="Disable incremental builds">
+      <state class="org.eclipse.ui.handlers.RegistryToggleState" id="org.eclipse.ui.commands.toggleState" />
+    </command>
+    <command id="org.metaborg.spoofax.eclipse.command.disable.editoranalysis" name="Disable editor analysis">
+      <state class="org.eclipse.ui.handlers.RegistryToggleState" id="org.eclipse.ui.commands.toggleState" />
+    </command>
+    <command id="org.metaborg.spoofax.eclipse.command.delay.editoranalysis" name="Delay editor analysis by 5s">
+      <state class="org.eclipse.ui.handlers.RegistryToggleState" id="org.eclipse.ui.commands.toggleState" />
+    </command>
+  </extension>
+  <extension point="org.eclipse.ui.handlers">
+    <handler
+      commandId="org.metaborg.spoofax.eclipse.command.disable.build"
+      class="org.metaborg.spoofax.eclipse.util.handler.ToggleHandler"
+    />
+    <handler
+      commandId="org.metaborg.spoofax.eclipse.command.disable.incrementalbuild"
+      class="org.metaborg.spoofax.eclipse.util.handler.ToggleHandler"
+    />
+    <handler
+      commandId="org.metaborg.spoofax.eclipse.command.disable.editoranalysis"
+      class="org.metaborg.spoofax.eclipse.util.handler.ToggleHandler"
+    />
+    <handler
+      commandId="org.metaborg.spoofax.eclipse.command.delay.editoranalysis"
+      class="org.metaborg.spoofax.eclipse.util.handler.ToggleHandler"
+    />
+  </extension>
   
-  
+
   <!-- Main menu -->
   <extension point="org.eclipse.ui.menus">
     <menuContribution locationURI="menu:org.eclipse.ui.main.menu?after=org.metaborg.spoofax.eclipse.separator">
       <menu label="Spoofax (meta)" id="org.metaborg.spoofax.eclipse.meta.menu.main">
+        <command commandId="org.metaborg.spoofax.eclipse.command.disable.build" style="toggle" />
+        <command commandId="org.metaborg.spoofax.eclipse.command.disable.incrementalbuild" style="toggle" />
+        <command commandId="org.metaborg.spoofax.eclipse.command.disable.editoranalysis" style="toggle" />
+
+        <command commandId="org.metaborg.spoofax.eclipse.command.delay.editoranalysis" style="toggle" />
+
+        <separator name="org.metaborg.spoofax.eclipse.separator" visible="true "/>
+
         <command commandId="org.metaborg.spoofax.eclipse.meta.command.issue.report" />
         <separator name="org.metaborg.spoofax.eclipse.meta.separator" visible="true "/>
+      </menu>
+    </menuContribution>
+    <menuContribution locationURI="menu:org.eclipse.ui.main.menu">
+      <menu label="Spoofax (meta)" id="org.metaborg.spoofax.eclipse.meta.menu.main">
+        <command commandId="org.metaborg.spoofax.eclipse.command.disable.build" style="toggle" />
+        <command commandId="org.metaborg.spoofax.eclipse.command.disable.incrementalbuild" style="toggle" />
+        <command commandId="org.metaborg.spoofax.eclipse.command.disable.editoranalysis" style="toggle" />
+
+        <command commandId="org.metaborg.spoofax.eclipse.command.delay.editoranalysis" style="toggle" />
+
+        <separator name="org.metaborg.spoofax.eclipse.separator" visible="true "/>
       </menu>
     </menuContribution>
   </extension>

--- a/org.metaborg.spoofax.eclipse/plugin.xml
+++ b/org.metaborg.spoofax.eclipse/plugin.xml
@@ -177,41 +177,6 @@
   </extension>
 
 
-  <!-- Disabling long-running operation commands -->
-  <extension point="org.eclipse.ui.commands">
-    <command id="org.metaborg.spoofax.eclipse.command.disable.build" name="Disable builds">
-      <state class="org.eclipse.ui.handlers.RegistryToggleState" id="org.eclipse.ui.commands.toggleState" />
-    </command>
-    <command id="org.metaborg.spoofax.eclipse.command.disable.incrementalbuild" name="Disable incremental builds">
-      <state class="org.eclipse.ui.handlers.RegistryToggleState" id="org.eclipse.ui.commands.toggleState" />
-    </command>
-    <command id="org.metaborg.spoofax.eclipse.command.disable.editoranalysis" name="Disable editor analysis">
-      <state class="org.eclipse.ui.handlers.RegistryToggleState" id="org.eclipse.ui.commands.toggleState" />
-    </command>
-    <command id="org.metaborg.spoofax.eclipse.command.delay.editoranalysis" name="Delay editor analysis by 5s">
-      <state class="org.eclipse.ui.handlers.RegistryToggleState" id="org.eclipse.ui.commands.toggleState" />
-    </command>
-  </extension>
-  <extension point="org.eclipse.ui.handlers">
-    <handler 
-      commandId="org.metaborg.spoofax.eclipse.command.disable.build"
-      class="org.metaborg.spoofax.eclipse.util.handler.ToggleHandler"
-    />
-    <handler 
-      commandId="org.metaborg.spoofax.eclipse.command.disable.incrementalbuild"
-      class="org.metaborg.spoofax.eclipse.util.handler.ToggleHandler"
-    />
-    <handler 
-      commandId="org.metaborg.spoofax.eclipse.command.disable.editoranalysis"
-      class="org.metaborg.spoofax.eclipse.util.handler.ToggleHandler"
-    />
-    <handler 
-      commandId="org.metaborg.spoofax.eclipse.command.delay.editoranalysis"
-      class="org.metaborg.spoofax.eclipse.util.handler.ToggleHandler"
-    />
-  </extension>
-
-
   <!-- Main menus -->
   <extension point="org.eclipse.ui.menus">
     <menuContribution locationURI="menu:org.eclipse.ui.main.menu">
@@ -220,17 +185,6 @@
           id="org.metaborg.spoofax.eclipse.menu" 
           class="org.metaborg.spoofax.eclipse.transform.TransformMenuContribution"
         />
-      </menu>
-    </menuContribution>
-    <menuContribution locationURI="menu:org.eclipse.ui.main.menu">
-      <menu label="Spoofax (meta)" id="org.metaborg.spoofax.eclipse.meta.menu.main">
-        <command commandId="org.metaborg.spoofax.eclipse.command.disable.build" style="toggle" />
-        <command commandId="org.metaborg.spoofax.eclipse.command.disable.incrementalbuild" style="toggle" />
-        <command commandId="org.metaborg.spoofax.eclipse.command.disable.editoranalysis" style="toggle" />
-        
-        <command commandId="org.metaborg.spoofax.eclipse.command.delay.editoranalysis" style="toggle" />
-        
-        <separator name="org.metaborg.spoofax.eclipse.separator" visible="true "/>
       </menu>
     </menuContribution>
   </extension>


### PR DESCRIPTION
This PR moves the four toggles (builds, incremental builds, analysis and delaying analysis) from the runtime plugin to the meta-tooling plugin.