### PR TITLE
Add stratego.compiler.pack to deps for the meta part of eclipse

### DIFF
--- a/org.metaborg.spoofax.eclipse.meta.feature/feature.xml
+++ b/org.metaborg.spoofax.eclipse.meta.feature/feature.xml
@@ -139,6 +139,11 @@
     unpack="true"
   />
   <plugin
+    id="stratego.compiler.pack"
+    version="2.6.0.qualifier"
+    unpack="false"
+  />
+  <plugin
     id="org.metaborg.meta.lang.stratego.eclipse"
     version="2.6.0.qualifier"
     unpack="true"


### PR DESCRIPTION
This set of PRs adds an incremental compilation option for Stratego. A clean build takes a while, but a small change is compiled faster than putting the compiler in CTree mode, despite separate compilation generating a JAR of fully compiled Stratego (which should in principle still be faster in execution than CTree). 
Known limitations of the current implementation for incremental compilation are:
- Overlays are not supported
- Mix-syntax (Stratego with concrete syntax mix-ins) is not tested yet
- Ctree/RTree include files are not supported

Other PRs:
https://github.com/metaborg/spoofax/pull/39
https://github.com/metaborg/spoofax-deploy/pull/17
https://github.com/metaborg/strategoxt/pull/25

This PR only adds a dependency on the new tool to pack strategy contributions from different files that were separately compiled. 