### PR TITLE
Adapt Spoofax 2 Eclipse to changes in Stratego incremental compiler

### DIFF
--- a/org.metaborg.spoofax.eclipse.externaldeps/pom.xml
+++ b/org.metaborg.spoofax.eclipse.externaldeps/pom.xml
@@ -232,7 +232,6 @@
             <Import-Package>
               !com.sun.*,
               !sun.*,
-              !javax.*,
               !groovy.*,
               !com.google.*,
               !org.apache.*,
@@ -243,6 +242,8 @@
               !com.jcraft.jsch.*,
               !org.springframework.*,
               !org.checkerframework.*,
+              javax.inject,
+              !javax.*,
               org.spoofax.*,
               org.metaborg.*,
               org.strategoxt.*,

--- a/org.metaborg.spoofax.eclipse.meta.feature/feature.xml
+++ b/org.metaborg.spoofax.eclipse.meta.feature/feature.xml
@@ -139,6 +139,11 @@
     unpack="false"
   />
   <plugin
+    id="stratego.build.spoofax2"
+    version="2.6.0.qualifier"
+    unpack="false"
+  />
+  <plugin
     id="org.metaborg.meta.lang.stratego.eclipse"
     version="2.6.0.qualifier"
     unpack="true"


### PR DESCRIPTION
- Adds the `stratego.build.spoofax2` project as a plugin
- Supports the use of `javax.inject`. Incidentally, supporting `javax.inject` also makes Spoofax 2 work up to the newest version of Eclipse (2020-06).

Needs to be merged with:
- https://github.com/metaborg/stratego/pull/10
- https://github.com/metaborg/spoofax/pull/69
- https://github.com/metaborg/spoofax-deploy/pull/29